### PR TITLE
Add customisable `sinon` library

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,12 @@ describe('my router', function () {
 
 });
 ```
+
+## Customisation
+
+If you want to use a different version of sinon to that which is included in reqres - or indeed a completely different stub/spy library - then you can set the sinon property to your own local version.
+
+```javascript
+const reqres = require('reqres');
+reqres.sinon = require('sinon');
+```

--- a/index.js
+++ b/index.js
@@ -1,5 +1,13 @@
-module.exports = {
+const stub = require('./lib/stub');
+const reqres = {
     req: require('./lib/req'),
     res: require('./lib/res'),
     app: require('./lib/app')
 };
+
+Object.defineProperty(reqres, 'sinon', {
+  get: () => stub(),
+  set: val => stub(val)
+});
+
+module.exports = reqres;

--- a/lib/app.js
+++ b/lib/app.js
@@ -1,9 +1,10 @@
 'use strict';
 
-const sinon = require('sinon');
+const stub = require('./stub');
 const View = require('express/lib/view');
 
 module.exports = () => {
+  const sinon = stub();
   const app = {
     get: sinon.stub(),
     set: sinon.spy((prop, val) => {

--- a/lib/req.js
+++ b/lib/req.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const sinon = require('sinon');
+const stub = require('./stub');
 const EventEmitter = require('events').EventEmitter;
 
 module.exports = settings => {
-
+  const sinon = stub();
   const defaults = {
 
     baseUrl: '/',

--- a/lib/res.js
+++ b/lib/res.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const sinon = require('sinon');
+const stub = require('./stub');
 const EventEmitter = require('events').EventEmitter;
 
 function complete() {
@@ -10,7 +10,7 @@ function complete() {
 }
 
 module.exports = settings => {
-
+  const sinon = stub();
   const defaults = {
     headersSent: false,
     locals: {},

--- a/lib/stub.js
+++ b/lib/stub.js
@@ -1,0 +1,18 @@
+const sinon = require('sinon');
+let _stub;
+const stub = lib => {
+  if (lib) {
+    if (typeof lib.stub !== 'function') {
+      throw new Error(`Could not set stub lib. Expected a "stub" method, found: ${typeof lib.stub}`);
+    }
+    if (typeof lib.spy !== 'function') {
+      throw new Error(`Could not set stub lib. Expected a "spy" method, found: ${typeof lib.spy}`);
+    }
+    _stub = lib;
+  }
+  return _stub;
+};
+
+stub(sinon);
+
+module.exports = stub;

--- a/lib/stub.js
+++ b/lib/stub.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const sinon = require('sinon');
 let _stub;
 const stub = lib => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -171,6 +171,15 @@
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
+    "choma": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/choma/-/choma-1.0.1.tgz",
+      "integrity": "sha1-e7K0uDF4V8BU80UY3rWB/mTeyuI=",
+      "dev": true,
+      "requires": {
+        "lodash.shuffle": "4.2.0"
+      }
+    },
     "circular-json": {
       "version": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
       "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
@@ -626,7 +635,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
       "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
-      "dev": true,
       "requires": {
         "samsam": "1.2.1"
       }
@@ -924,8 +932,7 @@
     "just-extend": {
       "version": "1.1.22",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.22.tgz",
-      "integrity": "sha1-MzCvdWyralQnAMZLLk5KoGLVL/8=",
-      "dev": true
+      "integrity": "sha1-MzCvdWyralQnAMZLLk5KoGLVL/8="
     },
     "levn": {
       "version": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -939,14 +946,18 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.shuffle": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.shuffle/-/lodash.shuffle-4.2.0.tgz",
+      "integrity": "sha1-FFtQU8+HX29cKjP0i26ZSMbse0s=",
       "dev": true
     },
     "lolex": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.1.2.tgz",
-      "integrity": "sha1-JpS5U8nqTQE+W4v7qJHJkQJbJik=",
-      "dev": true
+      "integrity": "sha1-JpS5U8nqTQE+W4v7qJHJkQJbJik="
     },
     "lru-cache": {
       "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
@@ -1055,8 +1066,7 @@
     "native-promise-only": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
-      "dev": true
+      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
     },
     "natural-compare": {
       "version": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -1071,7 +1081,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/nise/-/nise-1.1.0.tgz",
       "integrity": "sha512-lIFidCxB0mJGyq1i33tLRNojtMoYX95EAI7WQEU+/ees0w6hvXZQHZ7WD130Tjeh5+YJAUVLfQ3k/s9EA8jj+w==",
-      "dev": true,
       "requires": {
         "formatio": "1.2.0",
         "just-extend": "1.1.22",
@@ -1083,20 +1092,17 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "lolex": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
-          "dev": true
+          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY="
         },
         "path-to-regexp": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
           "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-          "dev": true,
           "requires": {
             "isarray": "0.0.1"
           }
@@ -1336,8 +1342,7 @@
     "samsam": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
-      "integrity": "sha1-7dOQk6MYQ3DLhZJDsr3yVefY6mc=",
-      "dev": true
+      "integrity": "sha1-7dOQk6MYQ3DLhZJDsr3yVefY6mc="
     },
     "send": {
       "version": "https://registry.npmjs.org/send/-/send-0.15.1.tgz",
@@ -1415,7 +1420,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.0.0.tgz",
       "integrity": "sha1-pUpfAjeqHdIhXl6ByJtCtQxP22s=",
-      "dev": true,
       "requires": {
         "diff": "3.3.1",
         "formatio": "1.2.0",
@@ -1432,20 +1436,17 @@
         "diff": {
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-          "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
-          "dev": true
+          "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
         },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "path-to-regexp": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
           "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-          "dev": true,
           "requires": {
             "isarray": "0.0.1"
           }
@@ -1550,8 +1551,7 @@
     "text-encoding": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
-      "dev": true
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
     },
     "text-table": {
       "version": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -1584,8 +1584,7 @@
     "type-detect": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
-      "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
-      "dev": true
+      "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo="
     },
     "type-is": {
       "version": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint ./lib && eslint ./test",
-    "unit": "mocha ./test --require ./test/helpers --recursive",
-    "examples": "mocha ./examples --recursive",
+    "unit": "mocha ./test --require ./test/helpers --recursive --require choma",
+    "examples": "mocha ./examples --recursive --require choma",
     "test": "npm run lint && npm run unit && npm run examples"
   },
   "repository": {
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "chai": "^4.1.2",
+    "choma": "^1.0.1",
     "eslint": "^3.19.0",
     "mocha": "^2.2.4",
     "sinon-chai": "^2.14.0"

--- a/test/spec.app.js
+++ b/test/spec.app.js
@@ -6,6 +6,10 @@ describe('app', function () {
 
   let app;
 
+  before(() => {
+    reqres.sinon = require('sinon');
+  });
+
   beforeEach(function () {
     app = reqres.app();
   });

--- a/test/spec.req.js
+++ b/test/spec.req.js
@@ -6,6 +6,10 @@ describe('req', function () {
 
   let req;
 
+  before(() => {
+    reqres.sinon = require('sinon');
+  });
+
   beforeEach(function () {
     req = reqres.req();
   });

--- a/test/spec.res.js
+++ b/test/spec.res.js
@@ -7,6 +7,10 @@ describe('res', function () {
 
   let res;
 
+  before(() => {
+    reqres.sinon = require('sinon');
+  });
+
   beforeEach(function () {
     res = reqres.res();
   });

--- a/test/spec.sinon.js
+++ b/test/spec.sinon.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const reqres = require('../');
+
+describe('sinon', function () {
+
+  it('uses the configured stub library to stub methods', function () {
+    class Stub {
+      returns() {}
+    }
+    function Spy() {}
+    reqres.sinon = {
+      stub: () => new Stub(),
+      spy: () => Spy
+    };
+    const res = reqres.res();
+    res.append.should.be.an.instanceOf(Stub);
+    res.send.should.equal(Spy);
+  });
+
+});


### PR DESCRIPTION
See https://github.com/lennym/reqres/issues/5

There is a need for users to be able to use a particular version of sinon for compatibility with other tools in their testing toolchain.

As such, expose a `reqres.sinon` property which can be used to set the `sinon` used internally by reqres to any user-provided library that implements `stub` and `spy`.